### PR TITLE
Don't take path from internal css class, use pathname instead.

### DIFF
--- a/src/inject.js
+++ b/src/inject.js
@@ -33,7 +33,7 @@ function is_code_page() {
 
 function setup_config() {
   // eg. /typpo/asterank
-  cfg.repo_home_link = $('.js-repo-home-link').attr('href');
+  cfg.repo_home_link = window.location.pathname.split('/').slice(0, 3).join('/');
   cfg.original_scroll_pos = $(window).scrollTop();
 
   cfg.$code_body = $('.js-file-line-container');


### PR DESCRIPTION
Hello!

This fixes the breakage: https://github.com/typpo/codenav/issues/8

After this change, it is supposed to be more robust, because it doesn't anymore rely on internal CSS property.

Please update the extension.